### PR TITLE
Unload systemwide cudatoolkit module

### DIFF
--- a/conf/perlmutter-env.sh
+++ b/conf/perlmutter-env.sh
@@ -13,7 +13,7 @@ export NTMAKE=8
 
 # needed for mpi4py
 # see https://docs.nersc.gov/development/languages/python/using-python-perlmutter
-module load cudatoolkit
+module unload cudatoolkit # ignore the systemwide cudatoolkit to avoid version conflicts
 export MPICC="cc -target-accel=nvidia80 -shared"
 
 for PRGENV in $(echo gnu intel cray nvidia)


### PR DESCRIPTION
Modifies `perlmutter-env.sh` so that the systemwide cudatoolkit module is ignored in order to avoid version conflicts.